### PR TITLE
:lock: Drop Admin Requirements 

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -5,7 +5,7 @@ function generateQuery(params) {
   let result = []
   Object.keys(params)
     .forEach(k => {
-      if(params[k]) 
+      if(params[k])
         result.push(esc(k) + '=' + esc(params[k]))
     })
   return result.join('&')
@@ -273,6 +273,17 @@ export const addFolder = (name, meta, parentId, parentType, reuseExisting = true
   },
 });
 
+export const updateFolderAccess = (id, accessList, recurse=false) => ({
+  type: types.UPDATE_OBJECT,
+  method: 'PUT',
+  objectType: 'folder',
+  path: `/folder/${id}/access`,
+  body: {
+    access:JSON.stringify(accessList),
+    recurse,
+  },
+});
+
 export const updateFolder = (id, name, meta) => ({
   type: types.UPDATE_OBJECT,
   method: 'PUT',
@@ -304,7 +315,7 @@ export const uploadFile = (name, fileObject, parentType, parentId) => ({
     size:fileObject.size,
     mimeType: fileObject.type,
   })}`,
-  isUpload: true, 
+  isUpload: true,
   body: fileObject,
   extraHeaders: { 'Content-Type': fileObject.type }
 })

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -259,6 +259,13 @@ export const getFolders = (parentId, name, parentType='collection') => ({
   path: `/folder?${generateQuery({parentId, parentType})}`,
 });
 
+export const getFolderAccess = (id) => ({
+  type: types.LIST_OBJECTS,
+  method: 'GET',
+  objectType: 'folder',
+  path: `/folder/${id}/access`,
+});
+
 export const addFolder = (name, meta, parentId, parentType, reuseExisting = true) => ({
   type: types.ADD_OBJECT,
   method: 'POST',

--- a/src/components/authRoute.js
+++ b/src/components/authRoute.js
@@ -15,7 +15,10 @@ class AuthRoute extends React.Component {
     if (user.admin) {
 
     } else if (role === 'user' || role === 'viewer') {
-      
+
+    } else if (user) {
+      redirectPath = '/library'
+
     } else {
       redirectPath = '/login'
     }

--- a/src/components/pages/library/index.jsx
+++ b/src/components/pages/library/index.jsx
@@ -107,7 +107,7 @@ class Home extends Component {
   }
 
   render() {
-    const {volumes, user} = this.props;
+    const {volumes, user, collection} = this.props;
     return (
       <div>
         <div className="volumes">
@@ -117,7 +117,7 @@ class Home extends Component {
             )
           }
           {
-            user && user.admin && <div className="plus-button" onClick={() => this.setState({form: true})}>
+            user && (collection && collection._accessLevel > 0) && <div className="plus-button" onClick={() => this.setState({form: true})}>
               <img src={plus} alt="plus"/>
             </div>
           }

--- a/src/components/pages/users/UserRow.jsx
+++ b/src/components/pages/users/UserRow.jsx
@@ -9,7 +9,7 @@ import ClearIcon from '@material-ui/icons/Clear';
 
 
 class UserRow extends Component {
-  
+
   render() {
     const {user, onSelect, onDelete} = this.props;
     if (user) {
@@ -17,15 +17,15 @@ class UserRow extends Component {
         <TableRow hover>
           <TableCell onClick={() => onSelect && onSelect(user)}>{user.login}</TableCell>
           <TableCell onClick={() => onSelect && onSelect(user)}>{user.firstName} {user.lastName}</TableCell>
-          <TableCell onClick={() => onSelect && onSelect(user)}>{user.email}</TableCell>
+          <TableCell onClick={() => onSelect && onSelect(user)}>{user.email || "🔐 private"}</TableCell>
           <TableCell><Button onClick={() => onDelete && onDelete(user)}><ClearIcon /></Button></TableCell>
         </TableRow>
       )
     } else {
       return (<TableRow></TableRow>)
     }
-    
-    
+
+
   }
 }
 

--- a/src/components/pages/users/modal/SelectUser.jsx
+++ b/src/components/pages/users/modal/SelectUser.jsx
@@ -56,7 +56,7 @@ class SelectUser extends Component {
             {user.login}
           </TableCell>
           <TableCell>{user.firstName} {user.lastName}</TableCell>
-          <TableCell>{user.email}</TableCell>
+          <TableCell>{user.email || "🔐 private"}</TableCell>
         </TableRow>)
   }
 
@@ -118,7 +118,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
-  
+
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SelectUser)

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -12,10 +12,10 @@ export const getTimestamp = (str) => {
   return (new Date(str)).getTime()
 }
 
-export const userContain = (user, keyword) => 
+export const userContain = (user, keyword) =>
 {
-return user && 
-    (user.firstName.includes(keyword) || user.lastName.includes(keyword) || user.email.includes(keyword))
+return user &&
+    (user.firstName.includes(keyword) || user.lastName.includes(keyword) || (user.email && user.email.includes(keyword)))
 }
 
 export const fileLink = (file, token) => {


### PR DESCRIPTION
Little changes to move edit authorization to the API level. Already running at https://app.mindlogger.info; in the next few minutes I'm going to give every current "admin" user edit access to Volumes, and then cut off all the admins from admin access except myself.

- :lock: Drop Admin Requirements
- :lipstick: :tractor: Log In to Library Instead of Login Screen
- :lock: :ambulance: Show 'closed_lock_with_key private' If Email Not Accessible 